### PR TITLE
Add support for running AJAX Spider

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -89,6 +89,20 @@ class ZAPCliTestCase(unittest.TestCase):
         self.assertFalse(helper_mock.called)
         self.assertEqual(result.exit_code, 2)
 
+    @patch('zapcli.zap_helper.ZAPHelper.run_ajax_spider')
+    def test_ajax_spider_url(self, helper_mock):
+        """Test AJAX Spider URL method."""
+        result = self.runner.invoke(cli.cli, ['--boring', '--api-key', '', 'ajax-spider', 'http://localhost/'])
+        helper_mock.assert_called_with('http://localhost/')
+        self.assertEqual(result.exit_code, 0)
+
+    @patch('zapcli.zap_helper.ZAPHelper.run_ajax_spider')
+    def test_ajax_spider_url_no_url(self, helper_mock):
+        """Test AJAX Spider URL method isn't called and an error status raised when no URL provided."""
+        result = self.runner.invoke(cli.cli, ['--boring', '--api-key', '', 'ajax-spider'])
+        self.assertFalse(helper_mock.called)
+        self.assertEqual(result.exit_code, 2)
+
     @patch.object(zap_helper.ZAPHelper, '__new__')
     def test_quick_scan(self, helper_mock):
         """Testing quick scan."""

--- a/tests/zap_helper_test.py
+++ b/tests/zap_helper_test.py
@@ -10,7 +10,7 @@ import unittest
 import urllib2
 
 from ddt import ddt, data, unpack
-from mock import Mock, MagicMock, mock_open, patch
+from mock import PropertyMock, Mock, MagicMock, mock_open, patch
 
 from zapcli import zap_helper
 from zapcli.exceptions import ZAPError
@@ -227,6 +227,21 @@ class ZAPHelperTestCase(unittest.TestCase):
 
         with self.assertRaises(ZAPError):
             self.zap_helper.run_active_scan('http://localhost')
+
+    def test_run_ajax_spider(self):
+        """Test running the AJAX Spider."""
+        def status_result():
+            """Return value of the status property."""
+            if status.call_count > 2:
+                return 'stopped'
+            return 'running'
+
+        class_mock = MagicMock()
+        status = PropertyMock(side_effect=status_result)
+        type(class_mock).status = status
+        self.zap_helper.zap.ajaxSpider = class_mock
+
+        self.zap_helper.run_ajax_spider('http://localhost', status_check_sleep=0)
 
     @data(
         (

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -160,6 +160,15 @@ def spider_url(zap_helper, url):
     zap_helper.run_spider(url)
 
 
+@cli.command('ajax-spider')
+@click.argument('url')
+@click.pass_obj
+def ajax_spider_url(zap_helper, url):
+    """Run the AJAX Spider against a URL."""
+    console.info('Running AJAX Spider...')
+    zap_helper.run_ajax_spider(url)
+
+
 @cli.command('active-scan', short_help='Run an Active Scan.')
 @click.argument('url')
 @click.option('--scanners', '-s', type=str, callback=validate_scanner_list,
@@ -208,6 +217,7 @@ def show_alerts(zap_helper, alert_level, output_format, exit_code):
               'subcommand to get a list of IDs. Available groups are: {0}.'.format(
                   ', '.join(['all'] + ZAPHelper.scanner_group_map.keys())))
 @click.option('--spider', is_flag=True, default=False, help='If set, run the spider before running the scan.')
+@click.option('--ajax-spider', is_flag=True, default=False, help='If set, run the AJAX Spider before running the scan.')
 @click.option('--recursive', '-r', is_flag=True, default=False, help='Make scan recursive.')
 @click.option('--alert-level', '-l', default='High', type=click.Choice(ZAPHelper.alert_levels.keys()),
               help='Minimum alert level to include in report.')
@@ -239,6 +249,9 @@ def quick_scan(zap_helper, url, **options):
 
         if options['spider']:
             zap_helper.run_spider(url)
+
+        if options['ajax_spider']:
+            zap_helper.run_ajax_spider(url)
 
         zap_helper.run_active_scan(url, recursive=options['recursive'])
 

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -123,7 +123,7 @@ class ZAPHelper(object):
         time.sleep(sleep_after_open)
 
     def run_spider(self, target_url, status_check_sleep=10):
-        """Run an active scan against a URL."""
+        """Run spider against a URL."""
         self.logger.debug('Spidering target {0}...'.format(target_url))
 
         self.zap.spider.scan(target_url, apikey=self.api_key)
@@ -148,6 +148,18 @@ class ZAPHelper(object):
             time.sleep(status_check_sleep)
 
         self.logger.debug('Scan #{0} completed'.format(scan_id))
+
+    def run_ajax_spider(self, target_url, status_check_sleep=10):
+        """Run AJAX Spider against a URL."""
+        self.logger.debug('AJAX Spidering target {0}...'.format(target_url))
+
+        self.zap.ajaxSpider.scan(target_url, apikey=self.api_key)
+
+        while self.zap.ajaxSpider.status == 'running':
+            self.logger.debug('AJAX Spider: {0}'.format(self.zap.ajaxSpider.status))
+            time.sleep(status_check_sleep)
+
+        self.logger.debug('AJAX Spider completed')
 
     def alerts(self, alert_level='High'):
         """Get a filtered list of alerts at the given alert level, and sorted by alert level."""


### PR DESCRIPTION
Add support for running AJAX Spider both on its own and as part of a
quick scan. This adds the command ajax-spider, which can be called
on its own:

    zap-cli ajax-spider http://127.0.0.1/

And also adds an AJAX Spider option to the quick-scan command, i.e.:

    zap-cli quick-scan --ajax-spider -r -s xss http://127.0.0.1/

Fixes #3