### PR TITLE
Handle errors when starting the spider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/
 dist/
 docs/_build/
 venv/
+.cache/
 
 # OS and IDE specific stuff
 *.iml

--- a/tests/zap_helper_test.py
+++ b/tests/zap_helper_test.py
@@ -197,11 +197,21 @@ class ZAPHelperTestCase(unittest.TestCase):
             return '50'
 
         class_mock = MagicMock()
+        class_mock.scan.return_value = '1'
         status = Mock(side_effect=status_result)
         class_mock.status = status
         self.zap_helper.zap.spider = class_mock
 
         self.zap_helper.run_spider('http://localhost', status_check_sleep=0)
+
+    def test_run_spider_error(self):
+        """Test running the spider when an error occurs."""
+        class_mock = MagicMock()
+        class_mock.scan.return_value = 'Provided parameter has illegal or unrecognized value'
+        self.zap_helper.zap.spider = class_mock
+
+        with self.assertRaises(ZAPError):
+            self.zap_helper.run_spider('http://localhost', status_check_sleep=0)
 
     def test_run_active_scan(self):
         """Test running an active scan."""

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -157,7 +157,8 @@ def open_url(zap_helper, url):
 def spider_url(zap_helper, url):
     """Run the spider against a URL."""
     console.info('Running spider...')
-    zap_helper.run_spider(url)
+    with zap_error_handler():
+        zap_helper.run_spider(url)
 
 
 @cli.command('ajax-spider')

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -126,13 +126,20 @@ class ZAPHelper(object):
         """Run spider against a URL."""
         self.logger.debug('Spidering target {0}...'.format(target_url))
 
-        self.zap.spider.scan(target_url, apikey=self.api_key)
+        scan_id = self.zap.spider.scan(target_url, apikey=self.api_key)
+
+        if not scan_id:
+            raise ZAPError('Error running spider.')
+        elif not scan_id.isdigit():
+            raise ZAPError('Error running spider: "{0}"'.format(scan_id))
+
+        self.logger.debug('Started spider with ID {0}...'.format(scan_id))
 
         while int(self.zap.spider.status()) < 100:
             self.logger.debug('Spider progress %: {0}'.format(self.zap.spider.status()))
             time.sleep(status_check_sleep)
 
-        self.logger.debug('Spider completed')
+        self.logger.debug('Spider #{0} completed'.format(scan_id))
 
     def run_active_scan(self, target_url, recursive=False, status_check_sleep=10):
         """Run an active scan against a URL."""


### PR DESCRIPTION
When the spider API fails to start, it returns an error message instead
of the scan ID. So, if the API returns something other than a digit, report
the error.

Fixes #9