### PR TITLE
Add a status command to check if ZAP is running

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ ZAP CLI can then be used with the following commands:
       shutdown     Shutdown the ZAP daemon.
       spider       Run the spider against a URL.
       start        Start the ZAP daemon.
+      status       Check if ZAP is running.
 
 You can use ``--help`` with any of the subcommands to get information on how to use
 them.

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -61,6 +61,37 @@ class ZAPCliTestCase(unittest.TestCase):
         helper_mock.assert_called_with()
         self.assertEqual(result.exit_code, 1)
 
+    @patch('zapcli.zap_helper.ZAPHelper.is_running')
+    def test_check_status_running(self, helper_mock):
+        """Test the status command."""
+        helper_mock.return_value = True
+        result = self.runner.invoke(cli.cli, ['--boring', '--api-key', '', 'status'])
+        self.assertEqual(result.exit_code, 0)
+
+    @patch('zapcli.zap_helper.ZAPHelper.is_running')
+    def test_check_status_not_running(self, helper_mock):
+        """Test the status command when ZAP is not running."""
+        helper_mock.return_value = False
+        result = self.runner.invoke(cli.cli, ['--boring', '--api-key', '', 'status'])
+        self.assertEqual(result.exit_code, 1)
+
+    @patch('zapcli.zap_helper.ZAPHelper.wait_for_zap')
+    @patch('zapcli.zap_helper.ZAPHelper.is_running')
+    def test_check_status_timeout(self, running_mock, wait_mock):
+        """Test the status command with a timeout."""
+        running_mock.return_value = False
+        wait_mock.side_effect = ZAPError('error')
+        result = self.runner.invoke(cli.cli, ['--boring', '--api-key', '', 'status', '-t', '0'])
+        self.assertEqual(result.exit_code, 1)
+
+    @patch('zapcli.zap_helper.ZAPHelper.wait_for_zap')
+    @patch('zapcli.zap_helper.ZAPHelper.is_running')
+    def test_check_status_timeout_success(self, running_mock, wait_mock):
+        """Test the status command with a successful wait for ZAP to start."""
+        running_mock.return_value = False
+        result = self.runner.invoke(cli.cli, ['--boring', '--api-key', '', 'status', '-t', '0'])
+        self.assertEqual(result.exit_code, 0)
+
     @patch('zapcli.zap_helper.ZAPHelper.open_url')
     def test_open_url(self, helper_mock):
         """Test open URL method."""

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -111,6 +111,35 @@ def shutdown_zap_daemon(zap_helper):
         zap_helper.shutdown()
 
 
+@cli.command('status', short_help='Check if ZAP is running.')
+@click.option('--timeout', '-t', type=int,
+              help='Wait this number of seconds for ZAP to have started')
+@click.pass_obj
+def check_status(zap_helper, timeout):
+    """
+    Check if ZAP is running and able to receive API calls.
+
+    You can provide a timeout option which is the amount of time in seconds
+    the command should wait for ZAP to start if it is not currently running.
+    This is useful to run before calling other commands if ZAP was started
+    outside of zap-cli. For example:
+
+        zap-cli status -t 60 && zap-cli open-url "http://127.0.0.1/"
+
+    Exits with code 1 if ZAP is either not running or the command timed out
+    waiting for ZAP to start.
+    """
+    with zap_error_handler():
+        if zap_helper.is_running():
+            console.info('ZAP is running')
+        elif timeout is not None:
+            zap_helper.wait_for_zap(timeout)
+            console.info('ZAP is running')
+        else:
+            console.error('ZAP is not running')
+            sys.exit(1)
+
+
 @cli.group(name='session', short_help='Manage sessions.')
 @click.pass_context
 def session_group(ctx):

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -83,11 +83,7 @@ class ZAPHelper(object):
                 zap_command, cwd=self.zap_path, stdout=log_file,
                 stderr=subprocess.STDOUT)
 
-        timeout_time = time.time() + self.timeout
-        while not self.is_running():
-            if time.time() > timeout_time:
-                raise ZAPError('Timed out waiting for ZAP to start.')
-            time.sleep(2)
+        self.wait_for_zap(self.timeout)
 
         self.logger.debug('ZAP started successfully.')
 
@@ -107,6 +103,14 @@ class ZAPHelper(object):
             time.sleep(2)
 
         self.logger.debug('ZAP shutdown successfully.')
+
+    def wait_for_zap(self, timeout):
+        """Wait for ZAP to be ready to receive API calls."""
+        timeout_time = time.time() + timeout
+        while not self.is_running():
+            if time.time() > timeout_time:
+                raise ZAPError('Timed out waiting for ZAP to start.')
+            time.sleep(2)
 
     def is_running(self):
         """Check if ZAP is running."""


### PR DESCRIPTION
Add a status command to check if ZAP is running and able to receive API
calls.

You can provide a timeout option which is the amount of time in seconds
the command should wait for ZAP to start if it is not currently running.
This is useful to run before calling other commands if ZAP was started
outside of zap-cli. For example:

    zap-cli status -t 60 && zap-cli open-url "http://127.0.0.1/"

Exits with code 1 if ZAP is either not running or the command timed out
waiting for ZAP to start.

/cc @stephendonner