### PR TITLE
Implemented report command

### DIFF
--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -299,6 +299,20 @@ class ZAPCliTestCase(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
+    @patch.object(zap_helper.ZAPHelper, '__new__')
+    def test_xmlreport(self, helper_mock):
+        """Testing XML report."""
+        result = self.runner.invoke(cli.cli,
+                                    ['report', '-o', 'foo.xml', '-f', 'xml'])
+        self.assertEqual(result.exit_code, 0)
+
+    @patch.object(zap_helper.ZAPHelper, '__new__')
+    def test_htmlreport(self, helper_mock):
+        """Testing HTML report."""
+        result = self.runner.invoke(cli.cli,
+                                    ['report', '-o', 'foo.hml', '-f', 'html'])
+        self.assertEqual(result.exit_code, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -299,18 +299,20 @@ class ZAPCliTestCase(unittest.TestCase):
 
         self.assertEqual(result, expected_result)
 
-    @patch.object(zap_helper.ZAPHelper, '__new__')
-    def test_xmlreport(self, helper_mock):
+    @patch('zapcli.zap_helper.ZAPHelper.xml_report')
+    def test_xml_report(self, report_mock):
         """Testing XML report."""
         result = self.runner.invoke(cli.cli,
                                     ['report', '-o', 'foo.xml', '-f', 'xml'])
+        report_mock.assert_called_with('foo.xml')
         self.assertEqual(result.exit_code, 0)
 
-    @patch.object(zap_helper.ZAPHelper, '__new__')
-    def test_htmlreport(self, helper_mock):
+    @patch('zapcli.zap_helper.ZAPHelper.html_report')
+    def test_html_report(self, report_mock):
         """Testing HTML report."""
         result = self.runner.invoke(cli.cli,
-                                    ['report', '-o', 'foo.hml', '-f', 'html'])
+                                    ['report', '-o', 'foo.html', '-f', 'html'])
+        report_mock.assert_called_with('foo.html')
         self.assertEqual(result.exit_code, 0)
 
 

--- a/tests/zap_helper_test.py
+++ b/tests/zap_helper_test.py
@@ -519,26 +519,34 @@ class ZAPHelperTestCase(unittest.TestCase):
             self.zap_helper.load_session(file_path)
 
     @patch('zapv2.core.xmlreport')
-    @patch('zapcli.zap_helper.ZAPHelper.write_report')
-    def test_xml_report(self, write_mock, xmlreport_mock):
+    def test_xml_report(self, xmlreport_mock):
         """Test XML report."""
         report_str = 'test_xml_report'
-        file_path = 'foo.xml'
         xmlreport_mock.return_value = report_str
-        self.zap_helper.xml_report(file_path)
+        file_path = 'foo.xml'
+        file_open_mock = mock_open()
+
+        with patch('zapcli.zap_helper.open', file_open_mock, create=True):
+            self.zap_helper.xml_report(file_path)
+
         xmlreport_mock.assert_called_with(apikey=self.api_key)
-        write_mock.assert_called_with(report_str, file_path)
+        file_open_mock.assert_called_with(file_path, 'w')
+        file_open_mock().write.assert_called_with(report_str)
 
     @patch('zapv2.core.htmlreport')
-    @patch('zapcli.zap_helper.ZAPHelper.write_report')
-    def test_html_report(self, write_mock, htmlreport_mock):
+    def test_html_report(self, htmlreport_mock):
         """Test HTML report."""
         report_str = 'test_html_report'
-        file_path = 'foo.html'
         htmlreport_mock.return_value = report_str
-        self.zap_helper.html_report(file_path)
+        file_path = 'foo.html'
+        file_open_mock = mock_open()
+
+        with patch('zapcli.zap_helper.open', file_open_mock, create=True):
+            self.zap_helper.html_report(file_path)
+
         htmlreport_mock.assert_called_with(apikey=self.api_key)
-        write_mock.assert_called_with(report_str, file_path)
+        file_open_mock.assert_called_with(file_path, 'w')
+        file_open_mock().write.assert_called_with(report_str)
 
 
 if __name__ == '__main__':

--- a/tests/zap_helper_test.py
+++ b/tests/zap_helper_test.py
@@ -520,23 +520,23 @@ class ZAPHelperTestCase(unittest.TestCase):
 
     @patch('zapv2.core.xmlreport')
     @patch('zapcli.zap_helper.ZAPHelper.write_report')
-    def test_xmlreport(self, write_mock, xmlreport_mock):
+    def test_xml_report(self, write_mock, xmlreport_mock):
         """Test XML report."""
         report_str = 'test_xml_report'
         file_path = 'foo.xml'
         xmlreport_mock.return_value = report_str
-        self.zap_helper.xmlreport(file_path)
+        self.zap_helper.xml_report(file_path)
         xmlreport_mock.assert_called_with(apikey=self.api_key)
         write_mock.assert_called_with(report_str, file_path)
 
     @patch('zapv2.core.htmlreport')
     @patch('zapcli.zap_helper.ZAPHelper.write_report')
-    def test_htmlreport(self, write_mock, htmlreport_mock):
+    def test_html_report(self, write_mock, htmlreport_mock):
         """Test HTML report."""
         report_str = 'test_html_report'
         file_path = 'foo.html'
         htmlreport_mock.return_value = report_str
-        self.zap_helper.htmlreport(file_path)
+        self.zap_helper.html_report(file_path)
         htmlreport_mock.assert_called_with(apikey=self.api_key)
         write_mock.assert_called_with(report_str, file_path)
 

--- a/tests/zap_helper_test.py
+++ b/tests/zap_helper_test.py
@@ -518,6 +518,28 @@ class ZAPHelperTestCase(unittest.TestCase):
         with self.assertRaises(ZAPError):
             self.zap_helper.load_session(file_path)
 
+    @patch('zapv2.core.xmlreport')
+    @patch('zapcli.zap_helper.ZAPHelper.write_report')
+    def test_xmlreport(self, write_mock, xmlreport_mock):
+        """Test XML report."""
+        report_str = 'test_xml_report'
+        file_path = 'foo.xml'
+        xmlreport_mock.return_value = report_str
+        self.zap_helper.xmlreport(file_path)
+        xmlreport_mock.assert_called_with(apikey=self.api_key)
+        write_mock.assert_called_with(report_str, file_path)
+
+    @patch('zapv2.core.htmlreport')
+    @patch('zapcli.zap_helper.ZAPHelper.write_report')
+    def test_htmlreport(self, write_mock, htmlreport_mock):
+        """Test HTML report."""
+        report_str = 'test_html_report'
+        file_path = 'foo.html'
+        htmlreport_mock.return_value = report_str
+        self.zap_helper.htmlreport(file_path)
+        htmlreport_mock.assert_called_with(apikey=self.api_key)
+        write_mock.assert_called_with(report_str, file_path)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -415,13 +415,13 @@ def exclude_from_scanners(zap_helper, pattern):
         zap_helper.exclude_from_all(pattern)
 
 
-@cli.command('report')
+@cli.command('report', short_help='Generate XML or HTML report.')
 @click.option('--output', '-o', help='Output file for report.')
 @click.option('--output-format', '-f', default='xml', type=click.Choice(['xml', 'html']),
               help='Report format.')
 @click.pass_obj
 def report(zap_helper, output, output_format):
-    """Generate report."""
+    """Generate XML or HTML report."""
     if output_format == 'html':
         zap_helper.htmlreport(output)
     else:

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -423,9 +423,9 @@ def exclude_from_scanners(zap_helper, pattern):
 def report(zap_helper, output, output_format):
     """Generate XML or HTML report."""
     if output_format == 'html':
-        zap_helper.htmlreport(output)
+        zap_helper.html_report(output)
     else:
-        zap_helper.xmlreport(output)
+        zap_helper.xml_report(output)
 
 
 def report_alerts(alerts, output_format='table'):

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -415,6 +415,19 @@ def exclude_from_scanners(zap_helper, pattern):
         zap_helper.exclude_from_all(pattern)
 
 
+@cli.command('report')
+@click.option('--output', '-o', help='Output file for report.')
+@click.option('--output-format', '-f', default='xml', type=click.Choice(['xml', 'html']),
+              help='Report format.')
+@click.pass_obj
+def report(zap_helper, output, output_format):
+    """Generate report."""
+    if output_format == 'html':
+        zap_helper.htmlreport(output)
+    else:
+        zap_helper.xmlreport(output)
+
+
 def report_alerts(alerts, output_format='table'):
     """
     Print our alerts in the given format.

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -330,3 +330,19 @@ class ZAPHelper(object):
             raise ZAPError('No file found at "{0}", cannot load session.'.format(file_path))
         self.logger.debug('Loading session from "{0}"'.format(file_path))
         self.zap.core.load_session(file_path, apikey=self.api_key)
+
+    def xmlreport(self, file_path):
+        """Generate xml report"""
+        self.logger.debug('Generating XML report')
+        report = self.zap.core.xmlreport(apikey=self.api_key)
+        self.write_report(report, file_path)
+
+    def htmlreport(self, file_path):
+        """Generate html report"""
+        self.logger.debug('Generating HTML report')
+        report = self.zap.core.htmlreport(apikey=self.api_key)
+        self.write_report(report, file_path)
+
+    def write_report(self, report, file_path):
+        with open(file_path, 'w') as f:
+            f.write(report)

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -331,13 +331,13 @@ class ZAPHelper(object):
         self.logger.debug('Loading session from "{0}"'.format(file_path))
         self.zap.core.load_session(file_path, apikey=self.api_key)
 
-    def xmlreport(self, file_path):
+    def xml_report(self, file_path):
         """Generate xml report"""
         self.logger.debug('Generating XML report')
         report = self.zap.core.xmlreport(apikey=self.api_key)
         self.write_report(report, file_path)
 
-    def htmlreport(self, file_path):
+    def html_report(self, file_path):
         """Generate html report"""
         self.logger.debug('Generating HTML report')
         report = self.zap.core.htmlreport(apikey=self.api_key)


### PR DESCRIPTION
This change add `report` command to `zap-cli` to be able to generate the
scan report. This command take 2 arguments:
- output file
- report format

Accepted format: `xml`, `html`

There is also the markdown report available in `python-owasp-zap-v2.4`, but it was implemented in the `0.0.9dev1` release, not in `0.0.8`:
https://github.com/zaproxy/zap-api-python/blob/0.0.9.dev1/src/zapv2/core.py#L354