### PR TITLE
Upgrade zap-cli to support ZAP 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     ],
     install_requires=[
         'click==4.0',
-        'python-owasp-zap-v2.4==0.0.8',
+        'python-owasp-zap-v2.4==0.0.9',
         'tabulate==0.7.5',
         'termcolor==1.1.0',
     ],

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -43,7 +43,7 @@ class ZAPHelper(object):
         self.zap_path = zap_path
         self.port = port
         self.proxy_url = '{0}:{1}'.format(url, self.port)
-        self.zap = ZAPv2(proxies={'http': self.proxy_url, 'https': self.proxy_url})
+        self.zap = ZAPv2(proxies={'http': self.proxy_url, 'https': self.proxy_url}, apikey=api_key)
         self.api_key = api_key
         self.logger = logger or console
 


### PR DESCRIPTION
This should be backwards compatible with running it against ZAP 2.5.0 as well.