### PR TITLE
Added option that doesn't require write access to ZAP installation directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ executing quick, targeted attacks.
 Installation
 ============
 
-To install the latest release from PyPI, you can run the following command: 
+To install the latest release from PyPI, you can run the following command:
 
 ::
 
@@ -56,6 +56,8 @@ ZAP CLI can then be used with the following commands:
                           or the value of the environment variable ZAP_URL.
       --api-key TEXT      The API key for using the ZAP API if required. Defaults
                           to the value of the environment variable ZAP_API_KEY.
+      --log-path TEXT     Path to a directory where to write the ZAP output
+                          logfile. Defaults to the value of --zap-path.
       --help              Show this message and exit.
 
     Commands:

--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,10 @@ ZAP CLI can then be used with the following commands:
                           or the value of the environment variable ZAP_URL.
       --api-key TEXT      The API key for using the ZAP API if required. Defaults
                           to the value of the environment variable ZAP_API_KEY.
-      --log-path TEXT     Path to a directory where to write the ZAP output
-                          logfile. Defaults to the value of --zap-path.
+      --log-path TEXT     Path to the directory in which to save the ZAP output
+                          log file. Defaults to the value of the environment
+                          variable ZAP_LOG_PATH and uses the value of --zap-path
+                          if it is not set.
       --help              Show this message and exit.
 
     Commands:

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -31,8 +31,10 @@ from zapcli.zap_helper import ZAPHelper
 @click.option('--api-key', default='', envvar='ZAP_API_KEY', type=str,
               help='The API key for using the ZAP API if required. Defaults to the value of the environment ' +
               'variable ZAP_API_KEY.')
+@click.option('--log-path', envvar='ZAP_LOG_PATH', type=str,
+              help='Path to a directory where to write the ZAP output logfile. Defaults to the value of --zap-path.')
 @click.pass_context
-def cli(ctx, boring, verbose, zap_path, port, zap_url, api_key):
+def cli(ctx, boring, verbose, zap_path, port, zap_url, api_key, log_path):
     """Main command line entry point."""
     console.colorize = not boring
 
@@ -41,7 +43,7 @@ def cli(ctx, boring, verbose, zap_path, port, zap_url, api_key):
     else:
         console.setLevel('INFO')
 
-    ctx.obj = ZAPHelper(zap_path=zap_path, port=port, url=zap_url, api_key=api_key)
+    ctx.obj = ZAPHelper(zap_path=zap_path, port=port, url=zap_url, api_key=api_key, log_path=log_path)
 
 
 @cli.command('start', short_help='Start the ZAP daemon.')

--- a/zapcli/cli.py
+++ b/zapcli/cli.py
@@ -32,7 +32,8 @@ from zapcli.zap_helper import ZAPHelper
               help='The API key for using the ZAP API if required. Defaults to the value of the environment ' +
               'variable ZAP_API_KEY.')
 @click.option('--log-path', envvar='ZAP_LOG_PATH', type=str,
-              help='Path to a directory where to write the ZAP output logfile. Defaults to the value of --zap-path.')
+              help='Path to the directory in which to save the ZAP output log file. Defaults to the value of ' +
+              'the environment variable ZAP_LOG_PATH and uses the value of --zap-path if it is not set.')
 @click.pass_context
 def cli(ctx, boring, verbose, zap_path, port, zap_url, api_key, log_path):
     """Main command line entry point."""

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -40,7 +40,7 @@ class ZAPHelper(object):
     timeout = 60
     _status_check_sleep = 10
 
-    def __init__(self, zap_path='', port=8090, url='http://127.0.0.1', api_key='', logger=None):
+    def __init__(self, zap_path='', port=8090, url='http://127.0.0.1', api_key='', log_path=None, logger=None):
         if os.path.isfile(zap_path):
             zap_path = os.path.dirname(zap_path)
         self.zap_path = zap_path
@@ -48,6 +48,7 @@ class ZAPHelper(object):
         self.proxy_url = '{0}:{1}'.format(url, self.port)
         self.zap = ZAPv2(proxies={'http': self.proxy_url, 'https': self.proxy_url}, apikey=api_key)
         self.api_key = api_key
+        self.log_path = log_path
         self.logger = logger or console
 
     @property
@@ -77,7 +78,10 @@ class ZAPHelper(object):
             extra_options = shlex.split(options)
             zap_command += extra_options
 
-        log_path = os.path.join(self.zap_path, 'zap.log')
+        if self.log_path == None:
+            log_path = os.path.join(self.zap_path, 'zap.log')
+        else:
+            log_path = os.path.join(self.log_path, 'zap.log')
 
         self.logger.debug('Starting ZAP process with command: {0}.'.format(' '.join(zap_command)))
         self.logger.debug('Logging to {0}'.format(log_path))

--- a/zapcli/zap_helper.py
+++ b/zapcli/zap_helper.py
@@ -78,7 +78,7 @@ class ZAPHelper(object):
             extra_options = shlex.split(options)
             zap_command += extra_options
 
-        if self.log_path == None:
+        if self.log_path is None:
             log_path = os.path.join(self.zap_path, 'zap.log')
         else:
             log_path = os.path.join(self.log_path, 'zap.log')


### PR DESCRIPTION
Hi

Currently, when running `zap-cli <some-options> start` to start the ZAP proxy, zap-cli tells ZAP to send it's output to a logfile located in the ZAP install folder.

For example, under Windows the location may be `C:\Program Files\OWASP\Zed Attack Proxy\zap.log` and under Linux the location may be `/opt/ZAP/zap.log`.

If the user running zap-cli does not have root/administrator privileges to write to the ZAP install directory, then ZAP will fail to start with an error like this...

```
$ zap-cli --verbose --api-key=XXXXXXXXXX --zap-path /opt/ZAP --port 8080 start
[INFO]            Starting ZAP daemon
[DEBUG]           Starting ZAP process with command: /opt/ZAP/zap.sh -daemon -port 8080.
[DEBUG]           Logging to /opt/ZAP/zap.log
Traceback (most recent call last):
  File "/home/g4z/.local/bin/zap-cli", line 11, in <module>
    load_entry_point('zapcli', 'console_scripts', 'zap-cli')()
  File "/home/g4z/.local/lib/python3.6/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/g4z/.local/lib/python3.6/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/g4z/.local/lib/python3.6/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/g4z/.local/lib/python3.6/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/g4z/.local/lib/python3.6/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/g4z/.local/lib/python3.6/site-packages/click/decorators.py", line 26, in new_func
    return ctx.invoke(f, ctx.obj, *args[1:], **kwargs)
  File "/home/g4z/.local/lib/python3.6/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/g4z/code/zap-cli/zapcli/cli.py", line 57, in start_zap_daemon
    zap_helper.start(options=start_options)
  File "/home/g4z/code/zap-cli/zapcli/zap_helper.py", line 88, in start
    with open(log_path, 'w+') as log_file:
PermissionError: [Errno 13] Permission denied: '/opt/ZAP/zap.log'
```

This same issue was raised in these tickets:

- https://github.com/Grunny/zap-cli/issues/62
- https://github.com/Grunny/zap-cli/issues/50

For me, the suggested resolution that `you must have write access to the ZAP installation folder` is not viable, therefore this PR adds a new option `--log-path` which allows the user to specify a different path for this log file.

If `--log-path` option is not passed as an argument, zap-cli will act exactly as it did before (tells ZAP to output to the ZAP install directory).

If `--log-path` is passed, zap-cli will tell ZAP to output to the file `zap.log` in the directory passed in `--log-path`.

Example usage:

```
$ pwd
/home/g4z/project1
$ zap-cli --log-path . --api-key=XXXXXX --zap-path /opt/ZAP --port 8080 --verbose start
```

The above command will write the ZAP output to the file: `/home/g4z/project1/zap.log`
