### PR TITLE
Change exit codes for alerts and quick-scan commands

### DIFF
--- a/zapcli/helpers.py
+++ b/zapcli/helpers.py
@@ -77,7 +77,7 @@ def zap_error_handler():
         yield
     except ZAPError as ex:
         console.error(str(ex))
-        sys.exit(1)
+        sys.exit(2)
 
 
 def report_alerts(alerts, output_format='table'):


### PR DESCRIPTION
Change exit codes for the alerts and quick-scan commands to more closely
match the behaviour of ZAP's scan scripts provided in the Docker image.
Now if any alerts are found for the given level, the command will exit with
a status of 1, and any other errors will produce the status code 2.

Closes #29.